### PR TITLE
feat(api): task 1 -> add /ask endpoint with guardrails, tracing and tool execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,12 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# IDE
+.idea/
+
+# macOS
+.DS_Store
+
+# Local docs / scratch
+starter_code/flow.html

--- a/starter_code/main.py
+++ b/starter_code/main.py
@@ -5,6 +5,7 @@ import sys
 import uuid
 
 import dotenv
+import uvicorn
 from langchain_core.documents import Document
 from langchain_core.messages import SystemMessage, HumanMessage, ToolMessage, AIMessage, trim_messages
 from langchain_core.prompts import MessagesPlaceholder, ChatPromptTemplate, PromptTemplate
@@ -18,14 +19,17 @@ from langfuse import observe, propagate_attributes, get_client
 from langfuse.langchain import CallbackHandler
 from nemoguardrails import RailsConfig
 from nemoguardrails.integrations.langchain.runnable_rails import RunnableRails
+from fastapi import FastAPI
+from pydantic import BaseModel
+
 
 # Load environment variables from .env file
 dotenv.load_dotenv()
 
 # Generate unique session_id and user_id once
-session_id = f"session-{uuid.uuid4().hex[:8]}"
+#session_id = f"session-{uuid.uuid4().hex[:8]}"
 users = ["James", "George", "Mike", "Sherlock"]
-user_id = users[uuid.uuid4().int % len(users)]
+#user_id = users[uuid.uuid4().int % len(users)]
 
 # Initialize the LLM with OpenAI API credentials (substitute for other models)
 llm = ChatOpenAI(
@@ -48,6 +52,85 @@ REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6380/0")
 # Initialize Langfuse client
 langfuse = get_client()
 
+# Initialize fast api app
+app = FastAPI()
+
+# ---------------------------
+# Pydantic model and Endpoint for asking question
+# ---------------------------
+
+class QueryRequest(BaseModel):
+    user_input: str
+    user_id: str
+    session_id: str
+
+@app.post("/ask/")
+def ask_question(question: QueryRequest):
+
+    # Request data
+    session_id = question.session_id
+    user_input = question.user_input.strip()
+    user_id = question.user_id
+
+    # Conversation history in redis
+    redis_history = RedisChatMessageHistory(
+        session_id=session_id,
+        redis_url=REDIS_URL,
+        ttl=3600,
+    )
+
+    with langfuse.start_as_current_observation(
+        as_type="span",
+        name="user-query",
+        input={"user_input": user_input}
+    ) as span:
+        with propagate_attributes(session_id=session_id, user_id=user_id):
+            # 4. Guardrails (input validation)
+            validation_result = input_rails.invoke(
+                {"user_input": user_input},
+                config={"run_name": "input-validation",
+                        "callbacks": [langfuse_handler]}
+            )
+            rail_triggered = (
+                    isinstance(validation_result, AIMessage)
+                    and validation_result.response_metadata.get("rails_triggered", False)
+            )
+            if rail_triggered:
+                span.update(output={"response": validation_result.content, "rail_triggered": True})
+                return {"response": validation_result.content, "blocked": True}
+
+            # 5. Load redis history + append user message
+            conversation = list(redis_history.messages)
+            user_message = HumanMessage(user_input)
+            conversation.append(user_message)
+
+            # 6. Context chain + decide which tool call
+            ai_with_tools = context_chain.invoke(
+                {"user_input": user_input, "conversation": conversation},
+                config={"run_name": "context",
+                        "callbacks": [langfuse_handler]}
+            )
+
+            # 7.  tool calls (
+            generate_context(
+                ai_with_tools, conversation,
+                config={"callbacks": [langfuse_handler]}
+            )
+
+            # 8. Review chain and final response
+            response = review_chain.invoke(
+                {"user_id": user_id, "user_input": user_input, "conversation": conversation},
+                config={"run_name": "final-response",
+                        "callbacks": [langfuse_handler]}
+            )
+        span.update(output={"response": response.content})
+
+    # 9. save user message plus response
+    redis_history.add_message(user_message)
+    redis_history.add_message(response)
+
+    # 10. Return text
+    return {"response": response.content}
 
 # ---------------------------
 # Load JSON Data and Build Qdrant Vector Store
@@ -208,199 +291,55 @@ def generate_context(ai_message: AIMessage, conversation: list, config: dict = N
             )
         )
 
+# List of available tools
+tools = [smartphone_info_tool]
 
+# Bind the tools to the language model instance
+llm_with_tools = llm.bind_tools(tools)
+
+context_lf_prompt = langfuse.get_prompt("context_system_prompt")
+review_lf_prompt = langfuse.get_prompt("review_system_prompt")
+
+# Create LangChain prompts from Langfuse prompts
+# Extract the first message (system message) and add MessagesPlaceholder for conversation history
+context_prompt = ChatPromptTemplate.from_messages([
+    context_lf_prompt.get_langchain_prompt()[0],
+    MessagesPlaceholder(variable_name="conversation"),
+])
+context_prompt.metadata = {"langfuse_prompt": context_lf_prompt}
+
+review_prompt = ChatPromptTemplate.from_messages([
+    review_lf_prompt.get_langchain_prompt()[0],
+    MessagesPlaceholder(variable_name="conversation"),
+])
+review_prompt.metadata = {"langfuse_prompt": review_lf_prompt}
+
+# Create message trimmer for context chain to limit token usage
+trimmer = trim_messages(
+    strategy="last",  # Keep the most recent messages
+    token_counter=llm,  # Use LLM to count tokens
+    max_tokens=500,  # Maximum tokens for conversation history
+    start_on="human",  # Start trimmed history with a human message
+    end_on=("human", "tool"),  # End on human or tool message
+    include_system=True,  # Always include system message
+)
+
+# Build chains (trimmer only on context_chain to manage tool call context)
+context_chain = context_prompt | trimmer | llm_with_tools
+review_chain = review_prompt | llm
+
+# Load NeMo Guardrails configuration
+guardrails_config = RailsConfig.from_path("config/")
+
+# Create guardrails instance for input validation only
+# We'll use it separately to validate user input before the chain
+input_rails = RunnableRails(guardrails_config, input_key="user_input")
+
+# Initialize the Langfuse handler once for the entire conversation
+langfuse_handler = CallbackHandler()
 # ---------------------------
 # Main Conversation Loop
 # ---------------------------
-def main():
-    # List of available tools
-    tools = [smartphone_info_tool]
-
-    # Bind the tools to the language model instance
-    llm_with_tools = llm.bind_tools(tools)
-
-    # Fetch prompts from Langfuse
-    context_lf_prompt = langfuse.get_prompt("context_system_prompt")
-    review_lf_prompt = langfuse.get_prompt("review_system_prompt")
-    goodbye_lf_prompt = langfuse.get_prompt("goodbye_system_prompt")
-
-    # Create LangChain prompts from Langfuse prompts
-    # Extract the first message (system message) and add MessagesPlaceholder for conversation history
-    context_prompt = ChatPromptTemplate.from_messages([
-        context_lf_prompt.get_langchain_prompt()[0],
-        MessagesPlaceholder(variable_name="conversation"),
-    ])
-    context_prompt.metadata = {"langfuse_prompt": context_lf_prompt}
-
-    review_prompt = ChatPromptTemplate.from_messages([
-        review_lf_prompt.get_langchain_prompt()[0],
-        MessagesPlaceholder(variable_name="conversation"),
-    ])
-    review_prompt.metadata = {"langfuse_prompt": review_lf_prompt}
-
-    # For goodbye_prompt, extract the content from the first message
-    goodbye_prompt = PromptTemplate.from_template(
-        goodbye_lf_prompt.get_langchain_prompt()[0][1]
-    )
-    goodbye_prompt.metadata = {"langfuse_prompt": goodbye_lf_prompt}
-
-    # Create message trimmer for context chain to limit token usage
-    trimmer = trim_messages(
-        strategy="last",  # Keep the most recent messages
-        token_counter=llm,  # Use LLM to count tokens
-        max_tokens=500,  # Maximum tokens for conversation history
-        start_on="human",  # Start trimmed history with a human message
-        end_on=("human", "tool"),  # End on human or tool message
-        include_system=True,  # Always include system message
-    )
-
-    # Build chains (trimmer only on context_chain to manage tool call context)
-    context_chain = context_prompt | trimmer | llm_with_tools
-    review_chain = review_prompt | llm
-    goodbye_chain = goodbye_prompt | llm
-
-    # Load NeMo Guardrails configuration
-    guardrails_config = RailsConfig.from_path("config/")
-
-    # Create guardrails instance for input validation only
-    # We'll use it separately to validate user input before the chain
-    input_rails = RunnableRails(guardrails_config, input_key="user_input")
-
-    # Initialize the Langfuse handler once for the entire conversation
-    langfuse_handler = CallbackHandler()
-
-    # Initialize Redis chat history with TTL (1 hour = 3600 seconds)
-    redis_history = RedisChatMessageHistory(
-        session_id=session_id,
-        redis_url=REDIS_URL,
-        ttl=3600  # Messages expire after 1 hour
-    )
-
-    try:
-        print("Welcome to the Smartphone Assistant! I can help you with smartphone features and comparisons.")
-        while True:
-            user_input = input("User: ").strip()
-            if user_input.lower() in ["exit", "quit", "bye", "end"]:
-                # Create a parent span for the goodbye message
-                with langfuse.start_as_current_observation(
-                    as_type="span",
-                    name="user-query",
-                    input={"user_input": user_input}
-                ) as span:
-                    with propagate_attributes(
-                        session_id=session_id,
-                        user_id=user_id
-                    ):
-                        goodbye_message = goodbye_chain.invoke(
-                            {"user_id": user_id},
-                            config={
-                                "run_name": "goodbye-message",
-                                "callbacks": [langfuse_handler]
-                            }
-                        )
-
-                        # Set the output on the parent span
-                        span.update(output={"response": goodbye_message.content})
-
-                print(f"System: {goodbye_message.content}")
-
-                # Collect user feedback about the entire conversation
-                feedback = input("\nWas this conversation helpful? (Yes/No): ").strip()
-                user_comment = input("Please give us a reason for your answer. This will help us improve: ").strip()
-
-                # Score at the session level (not individual trace)
-                langfuse.create_score(
-                    session_id=session_id,  # Use the session_id from the start of the conversation
-                    name="conversation_usefulness",
-                    value=feedback,
-                    data_type="CATEGORICAL",
-                    comment=user_comment
-                )
-
-                print("\nThank you for your feedback!")
-                break
-
-            # Load conversation history from Redis
-            conversation = list(redis_history.messages)
-
-            # Create user message
-            user_message = HumanMessage(user_input)
-            # Add to in-memory conversation for this turn
-            conversation.append(user_message)
-
-            # Create a parent span for this user query to group all chain invocations
-            with langfuse.start_as_current_observation(
-                as_type="span",
-                name="user-query",
-                input={"user_input": user_input}
-            ) as span:
-                # Propagate trace attributes to all child observations
-                with propagate_attributes(
-                    session_id=session_id,
-                    user_id=user_id
-                ):
-                    # First, validate input with guardrails (only passes user_input, not conversation)
-                    validation_result = input_rails.invoke(
-                        {"user_input": user_input},
-                        config={
-                            "run_name": "input-validation",
-                            "callbacks": [langfuse_handler]
-                        }
-                    )
-
-                    # Check if input rail was triggered
-                    # NeMo Guardrails adds metadata to the AIMessage when a rail is triggered
-                    rail_triggered = isinstance(validation_result, AIMessage) and validation_result.response_metadata.get("rails_triggered", False)
-
-                    if rail_triggered:
-                        # Rail triggered - skip further processing
-                        print(f"[NeMo Guardrails] Input BLOCKED: {validation_result.content}")
-                        span.update(output={"response": validation_result.content, "rail_triggered": True})
-                        print(f"System: {validation_result.content}")
-                        continue  # Skip saving to Redis and proceed to next input
-
-                    # Rail not triggered - continue with normal processing
-                    print(f"[NeMo Guardrails] Input ALLOWED: Validation passed")
-                    # Context chain invocation (with trimmer to limit tokens)
-                    ai_with_tools = context_chain.invoke(
-                        {"user_input": user_input, "conversation": conversation},
-                        config={
-                            "run_name": "context",
-                            "callbacks": [langfuse_handler]
-                        }
-                    )
-
-                    # Process tool calls and add results to in-memory conversation
-                    # Pass config with callbacks to ensure tool invocations are traced
-                    generate_context(
-                        ai_with_tools,
-                        conversation,
-                        config={"callbacks": [langfuse_handler]}
-                    )
-
-                    # Final response chain invocation
-                    response = review_chain.invoke(
-                        {"user_id": user_id, "user_input": user_input, "conversation": conversation},
-                        config={
-                            "run_name": "final-response",
-                            "callbacks": [langfuse_handler]
-                        }
-                    )
-
-                # Set the output on the parent span
-                span.update(output={"response": response.content})
-
-            print(f"System: {response.content}")
-
-            # Save ONLY clean messages to Redis (user input and final AI response)
-            # Tool calls and intermediate messages are NOT saved
-            redis_history.add_message(user_message)
-            redis_history.add_message(response)
-
-    except Exception as e:
-        print(f"An unexpected error occurred in the main loop: {e}")
-        sys.exit(1)
-
 
 if __name__ == "__main__":
-    main()
+    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)

--- a/starter_code/pyproject.toml
+++ b/starter_code/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "langchain-redis>=0.2.5",
     "redis>=7.4.0",
     "nemoguardrails>=0.22.0",
+    "fastapi",
+    "uvicorn>=0.48.0",
 ]
 
 [dependency-groups]

--- a/starter_code/uv.lock
+++ b/starter_code/uv.lock
@@ -14,6 +14,7 @@ name = "ai-engineer-deploy"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "fastapi" },
     { name = "langchain" },
     { name = "langchain-community" },
     { name = "langchain-core" },
@@ -26,10 +27,12 @@ dependencies = [
     { name = "qdrant-client" },
     { name = "redis" },
     { name = "requests" },
+    { name = "uvicorn" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "fastapi" },
     { name = "langchain" },
     { name = "langchain-community" },
     { name = "langchain-core" },
@@ -42,6 +45,7 @@ requires-dist = [
     { name = "qdrant-client" },
     { name = "redis", specifier = ">=7.4.0" },
     { name = "requests" },
+    { name = "uvicorn", specifier = ">=0.48.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -466,22 +470,38 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.136.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
+]
+
+[[package]]
 name = "fastembed"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub" },
-    { name = "loguru" },
-    { name = "mmh3" },
+    { name = "huggingface-hub", marker = "python_full_version < '3.14'" },
+    { name = "loguru", marker = "python_full_version < '3.14'" },
+    { name = "mmh3", marker = "python_full_version < '3.14'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
     { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "onnxruntime", version = "1.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pillow" },
-    { name = "py-rust-stemmers" },
-    { name = "requests" },
-    { name = "tokenizers" },
-    { name = "tqdm" },
+    { name = "onnxruntime", version = "1.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pillow", marker = "python_full_version < '3.14'" },
+    { name = "py-rust-stemmers", marker = "python_full_version < '3.14'" },
+    { name = "requests", marker = "python_full_version < '3.14'" },
+    { name = "tokenizers", marker = "python_full_version < '3.14'" },
+    { name = "tqdm", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/26/25/58865e36b6e8a9a0d0ff905b5601aa30db97956327c0df42ec4ed6accc21/fastembed-0.8.0.tar.gz", hash = "sha256:75966edfa8b006ee78514c726bd7f6a50721dadc89305279052be9db72fd53e8", size = 75115, upload-time = "2026-03-23T16:34:41.699Z" }
 wheels = [
@@ -885,15 +905,15 @@ name = "huggingface-hub"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
-    { name = "httpx" },
-    { name = "packaging" },
-    { name = "pyyaml" },
-    { name = "tqdm" },
-    { name = "typer" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "python_full_version < '3.14'" },
+    { name = "fsspec", marker = "python_full_version < '3.14'" },
+    { name = "hf-xet", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64') or (python_full_version < '3.14' and platform_machine == 'aarch64') or (python_full_version < '3.14' and platform_machine == 'amd64') or (python_full_version < '3.14' and platform_machine == 'arm64') or (python_full_version < '3.14' and platform_machine == 'x86_64')" },
+    { name = "httpx", marker = "python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version < '3.14'" },
+    { name = "pyyaml", marker = "python_full_version < '3.14'" },
+    { name = "tqdm", marker = "python_full_version < '3.14'" },
+    { name = "typer", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/76/b5efb3033d8499b17f9386beaf60f64c461798e1ee16d10bc9c0077beba5/huggingface_hub-1.5.0.tar.gz", hash = "sha256:f281838db29265880fb543de7a23b0f81d3504675de82044307ea3c6c62f799d", size = 695872, upload-time = "2026-02-26T15:35:32.745Z" }
 wheels = [
@@ -1333,8 +1353,8 @@ name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
 wheels = [
@@ -3274,6 +3294,19 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/bf/616a066c2760f6c2b1ae3437cc28149734d069fbb46511712beae118a68c/starlette-1.2.0.tar.gz", hash = "sha256:3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553", size = 2668923, upload-time = "2026-05-28T11:42:50.568Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/85/492183764d5d01d4514be3730fdb8e228a80605783099551c51627578b5d/starlette-1.2.0-py3-none-any.whl", hash = "sha256:36e0c76ac59157e75dc4b3bdeafba97fb04eaf1878045f15dbef666a6f092ed7", size = 73213, upload-time = "2026-05-28T11:42:48.801Z" },
+]
+
+[[package]]
 name = "sympy"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3360,7 +3393,7 @@ name = "tokenizers"
 version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub" },
+    { name = "huggingface-hub", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c1/60/21f715d9faba5f5407ff759472ade058ec4a507ad62bcea47cb847239a73/tokenizers-0.23.1.tar.gz", hash = "sha256:1feeeadf865a7915adc25445dea30e9933e593c31bb96c277cee36de227c8bfa", size = 365748, upload-time = "2026-04-27T14:43:25.606Z" }
 wheels = [
@@ -3572,6 +3605,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ed/15/dd1fab6f7fcd15f2c331d0c1f0f516bb1113a640216460f82be53db3dcf8/uuid_utils-0.16.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc0824a31898ef46a9d84d748c3abe27cdb615ac3773c53cc1f84fc8e66dc7c4", size = 328418, upload-time = "2026-05-19T07:44:52.38Z" },
     { url = "https://files.pythonhosted.org/packages/96/56/62dcd551b140cbeb0f87522da2015b4b9e5818327b920506ad88d28562b0/uuid_utils-0.16.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:abfbf5e0c47fb31b37164a99515104e449a0bee36a071dc8b105457a2b35a5e6", size = 356177, upload-time = "2026-05-19T07:45:42.856Z" },
     { url = "https://files.pythonhosted.org/packages/44/e7/3937b9a9d6745b94dbe7b86531e098db8c53b77c8d07df7daa9577a47b8e/uuid_utils-0.16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:680799a9ade01d69c53cb9d41392ced24919d4f600bfab5060b61fca37510097", size = 178508, upload-time = "2026-05-19T07:43:43.774Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.48.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/bf/f6544ba992ddb9a6077343a576f9844f7f8f06ab819aefd00206e9255f18/uvicorn-0.48.0.tar.gz", hash = "sha256:a5504207195d08c2511bf9125ede5ac4a4b71725d519e758d01dcf0bc2d31c37", size = 91074, upload-time = "2026-05-24T12:08:41.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/be/72532be3da7acc5fdfbccdb95215cd04f995a0886532a5b423f929cda4cc/uvicorn-0.48.0-py3-none-any.whl", hash = "sha256:48097851328b87ec36117d3d575234519eb58c2b22d79666e9bbc6c49a761dad", size = 71410, upload-time = "2026-05-24T12:08:40.258Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements Task 1, converts the CLI conversation loop into a FastAPI `POST /ask/` endpoint while keeping the full production-grade pipeline (monitoring, guardrails, RAG, history) untouched.

## How to test

```bash
uv run python main.py

# Normal query
curl -X POST http://localhost:8000/ask/ \
  -H "Content-Type: application/json" \
  -d '{"user_input": "Tell me about the iPhone 15", "user_id": "u1", "session_id": "s1"}'

# Guardrail-blocked query (refunds/orders)
curl -X POST http://localhost:8000/ask/ \
  -H "Content-Type: application/json" \
  -d '{"user_input": "I want to return my phone", "user_id": "u1", "session_id": "s1"}'

# Memory check (same session_id)
curl -X POST http://localhost:8000/ask/ \
  -H "Content-Type: application/json" \
  -d '{"user_input": "And the battery?", "user_id": "u1", "session_id": "s1"}'
```

